### PR TITLE
Conditional symlinking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,19 +14,71 @@ namespace :symlink do
 end
 
 def symlink(options = {})
-  dir   = File.dirname(__FILE__)
   files = Dir.glob('.*') - ['.git', '.gitmodules', '.', '..'] - options[:skip].to_a
-  existing_files = []
-  
   files.each do |file|
-    existing_files << "~/#{file}" if File.exists?("#{ENV['HOME']}/#{file}")
-  end
-  
-  if existing_files.any?
-    puts "Existing config files were found (#{existing_files.join(' ')}).  Please back them up and remove them first."
-  else
-    files.each do |file|
-      sh("ln -s #{File.join(dir, file)} #{ENV['HOME']}/#{file}")
+    case
+      when file_identical?(file) : skip_identical_file(file)
+      when replace_all_files?    : link_file(file)
+      when file_missing?(file)   : link_file(file)
+      else                         prompt_to_link_file(file)
     end
   end
+end
+
+
+
+
+# FILE CHECKS
+def file_exists?(file)
+  File.exists?("#{ENV['HOME']}/#{file}")
+end
+
+def file_missing?(file)
+  !file_exists?(file)
+end
+
+def file_identical?(file)
+  File.identical? file, File.join(ENV['HOME'], "#{file}")
+end
+
+def replace_all_files?
+  @replace_all == true
+end
+
+
+
+
+# FILE ACTIONS
+def prompt_to_link_file(file)
+  print "overwrite? ~/#{file} [ynaq]  "
+  case $stdin.gets.chomp
+    when 'y' : replace_file(file)
+    when 'a' : replace_all(file)
+    when 'q' : exit      
+    else       skip_file(file)
+  end
+end
+
+def link_file(file)
+  puts " => symlinking #{file}"
+  directory = File.dirname(__FILE__)
+  sh("ln -s #{File.join(directory, file)} #{ENV['HOME']}/#{file}")
+end
+
+def replace_file(file)
+  sh "rm -rf #{ENV['HOME']}/#{file}"
+  link_file(file)
+end
+
+def replace_all(file)
+  @replace_all = true
+  replace_file(file)
+end
+
+def skip_file(file)
+  puts " => skipping ~/#{file}" 
+end
+
+def skip_identical_file(file)
+  puts " => skipping identical ~/#{file}"
 end


### PR DESCRIPTION
I very much liked most of the configs from the pairing-config, but there were some configs that I didn't want to overwrite.  (Example: my vim config that I manage separately.)

By default, the current rake task forced me to take all symlinked customizations or nothing at all.

I did a quick modification of the rake task to allow conditional prompting for each symlink.  If no symlink exists, it will create it.  If the symlink points to the same file (is identical), it will skip it.  If the symlink exists, but is different, it will prompt the user for what to do (overwrite it, leave the existing one, or replace it and all after it).

There is room for refactoring, but it seemed to work for what I needed.
