### PR TITLE
"now" update for oh-my-zsh people

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -71,6 +71,6 @@ alias rails-bootstrap='ruby ~/rails-bootstrap/rails-bootstrap.rb'
 
 # history
 alias sudo='sudo ' # allow running sudo against an alias
-alias redo='`cat $HOME/.zsh_history | tail -n2 | head -n1`' # run last command again
+alias redo='`\history -n | tail -n1`' # run last command again
 alias now='sudo redo' # I meant sudo on that last command
 


### PR DESCRIPTION
Based on comments from Boston in thread:
https://github.com/edgecase/pairing-config/pull/5

The "now" alias was not working for people using oh-my-zsh. This changes the "redo" alias so that redo and now will work for the oh-my-zsh folks.
