### PR TITLE
Can't gitrm files with spaces in the name or directory.

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -48,7 +48,7 @@ alias ru='bundle exec rackup config.ru'
 
 # Git
 
-alias gitrm='git ls-files --deleted | xargs git rm'
+alias gitrm='git ls-files -z --deleted | xargs -0 git rm'
 alias gitx='gitx --all'
 alias gpci='git-pair commit'
 alias gp='git pair'


### PR DESCRIPTION
Added the -z flag to git ls-files and the -0 flag to xargs. http://jennyandlih.com/using-git-ls-files-input-xargs
